### PR TITLE
Update version of middleware container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.12
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.10
     ports:
       - 9200:9200
       - 9300:9300
@@ -25,7 +25,7 @@ services:
       retries: 10
 
   activemq:
-    image: rmohr/activemq:5.15.9
+    image: islandora/activemq:main
     ports:
       - 61616:61616
       - 8161:8161

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.14
+FROM nginx:stable
 
 RUN apt-get update && apt-get install -y \
   vim \

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -2,6 +2,7 @@ server {
     listen       80;
     server_name  personium;
 
+    client_max_body_size    10m;
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 


### PR DESCRIPTION
Updated container middleware to support apple silicon(arm64/v8).

ElasticSearch 6.6.1 → 7.17.10
ActiveMQ rmohr/activemq:5.15.4 → islandora/activemq:main
Nginx 1.14 → stable